### PR TITLE
Include protobuf as pkgconfig-depends

### DIFF
--- a/libphonenumber.cabal
+++ b/libphonenumber.cabal
@@ -69,6 +69,7 @@ library
         , deepseq >= 1.4.4 && < 1.6
         , transformers >= 0.5.5 && < 0.7
     build-tool-depends: c2hs:c2hs
+    pkgconfig-depends: protobuf
     include-dirs: include
     includes:
         , c_phonenumber.h
@@ -78,7 +79,6 @@ library
         , cxxbits/c_phonenumberutil.cpp
     extra-libraries:
         , phonenumber
-        , protobuf
     if impl(ghc >= 9.4)
         build-depends: system-cxx-std-lib
     else


### PR DESCRIPTION
With extra-libraries cabal doesn't track version of the C library, so every time you update system dependencies and it's updated, this library breaks and you have to nuke the whole cabal store.